### PR TITLE
Add basic GamePanel test

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -10,6 +10,11 @@
 <project name="Kulki" default="default" basedir=".">
     <description>Builds, tests, and runs the project Kulki.</description>
     <import file="nbproject/build-impl.xml"/>
+
+    <!-- Override default test target to run simple assertion based tests -->
+    <target name="test" depends="compile-test">
+        <java classname="kulki.GamePanelTest" classpath="${run.test.classpath}" failonerror="true"/>
+    </target>
     <!--
 
     There exist several targets which are by default empty and which can be 

--- a/src/kulki/BallGame.java
+++ b/src/kulki/BallGame.java
@@ -29,9 +29,10 @@ class GamePanel extends JPanel implements ActionListener {
     private int paddleX = 250;
     private int score = 0;
     private double speedMultiplier = 1.1;
+    private Timer timer;
 
     public GamePanel() {
-        Timer timer = new Timer(10, this);
+        timer = new Timer(10, this);
         timer.start();
         addMouseMotionListener(new MouseAdapter() {
             @Override
@@ -73,5 +74,16 @@ class GamePanel extends JPanel implements ActionListener {
         }
 
         repaint();
+    }
+
+    // Methods below are package-private to facilitate unit testing
+    void stopTimer() {
+        if (timer != null) {
+            timer.stop();
+        }
+    }
+
+    int getScore() {
+        return score;
     }
 }

--- a/test/kulki/GamePanelTest.java
+++ b/test/kulki/GamePanelTest.java
@@ -1,0 +1,33 @@
+package kulki;
+
+public class GamePanelTest {
+    public static void main(String[] args) throws Exception {
+        GamePanel panel = new GamePanel();
+        panel.setSize(600, 400);
+        panel.stopTimer();
+
+        java.lang.reflect.Field xField = GamePanel.class.getDeclaredField("x");
+        xField.setAccessible(true);
+        java.lang.reflect.Field yField = GamePanel.class.getDeclaredField("y");
+        yField.setAccessible(true);
+        java.lang.reflect.Field dxField = GamePanel.class.getDeclaredField("dx");
+        dxField.setAccessible(true);
+        java.lang.reflect.Field dyField = GamePanel.class.getDeclaredField("dy");
+        dyField.setAccessible(true);
+        java.lang.reflect.Field paddleXField = GamePanel.class.getDeclaredField("paddleX");
+        paddleXField.setAccessible(true);
+
+        int paddleX = paddleXField.getInt(panel);
+        xField.setInt(panel, paddleX + 20);
+        yField.setInt(panel, panel.getHeight() - 20 - 10); // BALL_SIZE and PADDLE_HEIGHT
+        dxField.setDouble(panel, 0);
+        dyField.setDouble(panel, 1);
+
+        int before = panel.getScore();
+        panel.actionPerformed(null);
+        int after = panel.getScore();
+        if (after != before + 1) {
+            throw new AssertionError("Score did not increase after paddle hit");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose timer and score for testing
- implement a simple `GamePanelTest` under `test/kulki`
- override the Ant `test` target to run the new test without JUnit

## Testing
- `ant test` *(fails: `ant` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683feb7640d08333822c0268de3a1f58